### PR TITLE
Feature/#4: Add Icon component

### DIFF
--- a/libs/ui/src/components/button/button.module.css
+++ b/libs/ui/src/components/button/button.module.css
@@ -1,4 +1,8 @@
 .button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
   height: 3rem;
   padding: 0 2rem;
   border: none;

--- a/libs/ui/src/components/button/button.stories.tsx
+++ b/libs/ui/src/components/button/button.stories.tsx
@@ -14,3 +14,20 @@ export const Primary: StoryObj<ButtonProps> = {
     disabled: false,
   },
 };
+
+export const Secondary: StoryObj<ButtonProps> = {
+  args: {
+    children: 'Click me',
+    variant: 'secondary',
+    disabled: false,
+  },
+};
+
+export const WithIcon: StoryObj<ButtonProps> = {
+  args: {
+    children: 'New Feed',
+    variant: 'primary',
+    disabled: false,
+    iconLeft: 'plus',
+  },
+};

--- a/libs/ui/src/components/button/button.tsx
+++ b/libs/ui/src/components/button/button.tsx
@@ -1,3 +1,4 @@
+import Icon, { IconProps } from '../icon/icon';
 import styles from './button.module.css';
 
 export type ButtonVariant = 'primary' | 'secondary';
@@ -6,18 +7,24 @@ export interface ButtonProps {
   children: string;
   variant?: ButtonVariant;
   disabled?: boolean;
+  iconLeft?: IconProps['name'];
+  iconRight?: IconProps['name'];
 }
 
 export function Button({
   children,
   variant = 'primary',
   disabled = false,
+  iconLeft,
+  iconRight,
 }: ButtonProps) {
   const className = `${styles.button} ${styles[variant]}`;
 
   return (
     <button className={className} disabled={disabled}>
-      {children}
+      {iconLeft && <Icon name={iconLeft} />}
+      <span>{children}</span>
+      {iconRight && <Icon name={iconRight} />}
     </button>
   );
 }

--- a/libs/ui/src/components/icon/icon.spec.tsx
+++ b/libs/ui/src/components/icon/icon.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+
+import Icon from './icon';
+
+describe('Icon', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<Icon name="arrow-back" />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/ui/src/components/icon/icon.stories.tsx
+++ b/libs/ui/src/components/icon/icon.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Icon, { IconProps } from './icon';
+
+const meta: Meta<typeof Icon> = {
+  component: Icon,
+  title: 'Icon',
+};
+export default meta;
+
+export const Primary: StoryObj<IconProps> = {
+  args: {
+    name: 'arrow-back',
+  },
+};

--- a/libs/ui/src/components/icon/icon.stories.tsx
+++ b/libs/ui/src/components/icon/icon.stories.tsx
@@ -10,5 +10,6 @@ export default meta;
 export const Primary: StoryObj<IconProps> = {
   args: {
     name: 'arrow-back',
+    size: 'md',
   },
 };

--- a/libs/ui/src/components/icon/icon.tsx
+++ b/libs/ui/src/components/icon/icon.tsx
@@ -1,0 +1,100 @@
+import { BiCategory } from 'react-icons/bi';
+import {
+  BsCapslock,
+  BsChevronLeft,
+  BsChevronRight,
+  BsEnvelope,
+  BsMailbox,
+  BsTrash,
+} from 'react-icons/bs';
+import { FiExternalLink } from 'react-icons/fi';
+import { HiLink } from 'react-icons/hi';
+import { IoMdCopy } from 'react-icons/io';
+import { IoChevronDownSharp, IoChevronUpSharp } from 'react-icons/io5';
+import { LuTextSearch } from 'react-icons/lu';
+import {
+  MdAdd,
+  MdArrowBack,
+  MdBookmarkAdd,
+  MdBookmarkRemove,
+  MdCheck,
+  MdChevronLeft,
+  MdChevronRight,
+  MdClose,
+  MdError,
+  MdLockOutline,
+  MdOutlineArticle,
+  MdOutlineBackspace,
+  MdOutlineEdit,
+  MdOutlineSettings,
+  MdOutlineShare,
+  MdOutlineVisibility,
+  MdOutlineVisibilityOff,
+  MdRefresh,
+  MdSearch,
+} from 'react-icons/md';
+import { RiZoomInLine, RiZoomOutLine } from 'react-icons/ri';
+import { SlOptions, SlOptionsVertical } from 'react-icons/sl';
+import { TbEyeCheck, TbEyeX } from 'react-icons/tb';
+
+const icons = {
+  'arrow-back': MdArrowBack,
+  backspace: MdOutlineBackspace,
+  'caps-lock': BsCapslock,
+  categories: BiCategory,
+  'check-mark': MdCheck,
+  'chevron-down': IoChevronDownSharp,
+  'chevron-left': MdChevronLeft,
+  'chevron-left-light': BsChevronLeft,
+  'chevron-right': MdChevronRight,
+  'chevron-right-light': BsChevronRight,
+  'chevron-up': IoChevronUpSharp,
+  close: MdClose,
+  copy: IoMdCopy,
+  document: MdOutlineArticle,
+  edit: MdOutlineEdit,
+  error: MdError,
+  external: FiExternalLink,
+  hide: MdOutlineVisibilityOff,
+  link: HiLink,
+  mail: BsEnvelope,
+  mailbox: BsMailbox,
+  'mark-read': TbEyeCheck,
+  'mark-unread': TbEyeX,
+  'options-horizontal': SlOptions,
+  'options-vertical': SlOptionsVertical,
+  padlock: MdLockOutline,
+  plus: MdAdd,
+  refresh: MdRefresh,
+  'save-article': MdBookmarkAdd,
+  search: MdSearch,
+  'search-text': LuTextSearch,
+  settings: MdOutlineSettings,
+  share: MdOutlineShare,
+  show: MdOutlineVisibility,
+  trash: BsTrash,
+  'unsave-article': MdBookmarkRemove,
+  'zoom-in': RiZoomInLine,
+  'zoom-out': RiZoomOutLine,
+};
+
+const sizes = {
+  xs: '1rem',
+  sm: '1.25rem',
+  md: '1.5rem',
+  lg: '2rem',
+  xl: '2.5rem',
+};
+
+export interface IconProps {
+  name: keyof typeof icons;
+  size?: keyof typeof sizes;
+}
+
+export function Icon({ name, size = 'md' }: IconProps) {
+  const IconComponent = icons[name];
+
+  return <IconComponent size={sizes[size]} />;
+}
+
+export default Icon;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "next": "~15.1.4",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-icons": "^5.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-icons:
+        specifier: ^5.4.0
+        version: 5.4.0(react@18.3.1)
     devDependencies:
       '@babel/core':
         specifier: ^7.14.5
@@ -6058,6 +6061,11 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-icons@5.4.0:
+    resolution: {integrity: sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -14552,6 +14560,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-icons@5.4.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
- Install [react-icons](https://react-icons.github.io/react-icons/) library
- Create `Icon` component
- Define a list of icons to render inside the `Icon` component
- Add `iconLeft` and `iconRight` props to the `Button` components that use the new `Icon` component 